### PR TITLE
getDefault move

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following snippet of code is all you need to send a transaction to our Testn
 const sdk = require('tupelo-wasm-sdk')
 
 // setup a connection to the default community and Tupelo TestNet
-const community = await sdk.getDefault() 
+const community = await sdk.Community.getDefault() 
 
 // Generate a new public/private keypair
 const key = await sdk.EcdsaKey.generate() 
@@ -35,7 +35,7 @@ You can also find ChainTrees by their DID and resolve data on them, easily:
 const sdk = require('tupelo-wasm-sdk')
 
 // setup a connection to the default community and Tupelo TestNet
-const community = await sdk.getDefault() 
+const community = await sdk.Community.getDefault() 
 
 const tip = await community.getTip("did:tupelo:0xD1a9826f3A06d393368C9949535De802A35cD6b2")
 

--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -58,6 +58,11 @@ export class Community extends EventEmitter {
     waitForStart(): Promise<Community>;
 }
 
+// @public (undocumented)
+export namespace Community {
+    export function getDefault(repo?: Repo): Promise<Community>;
+}
+
 // @public
 export class Dag {
     constructor(tip: CID_2, store: IBlockService);
@@ -91,9 +96,6 @@ export class EcdsaKey {
 
 // @public
 export const establishTokenTransaction: (name: string, maximum: number) => Transaction_2;
-
-// @public (undocumented)
-export const getDefault: (repo?: Repo | undefined) => Promise<Community>;
 
 // @public
 export interface IBitSwap {

--- a/src/community/default.integration.ts
+++ b/src/community/default.integration.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import 'mocha';
-import {getDefault} from './default'
+import {Community} from './community'
 
 describe('default community', ()=> {
     it('works with no options', async () => {
-        const c = await getDefault()
+        const c = await Community.getDefault()
         expect(c).to.exist
     })
 })

--- a/src/community/default.ts
+++ b/src/community/default.ts
@@ -62,12 +62,12 @@ export const defaultNotaryGroup = tomlToNotaryGroup(testNetToml)
 
 let _defaultCommunity: Community|undefined
 
+
 /**
  * 
- * @param repo - (optional) - a {@link Repo} object (wrapper around an IPFS repo).
- * @public
+ * @internal
  */
-export const getDefault = async (repo?:Repo): Promise<Community> => {
+export const _getDefault = async (repo?:Repo): Promise<Community> => {
     if (repo == undefined) {
         repo = new Repo("default")
         await repo.init({})

--- a/src/community/index.ts
+++ b/src/community/index.ts
@@ -1,4 +1,4 @@
-export * from './default'
+export {defaultNotaryGroup} from './default'
 export * from './community'
 export * from './wrappedbitswap'
 export * from './wrappedblockservice'


### PR DESCRIPTION
This moves the getDefault function into the Community namespace. It's a breaking api... so will need to update the explorer and examples. I think this is a good time to do that though.