### PR TITLE
add a second community because multiple tips is a realistic interaction

### DIFF
--- a/wasmtupelo/configs/community2.toml
+++ b/wasmtupelo/configs/community2.toml
@@ -1,0 +1,13 @@
+Name = "integrationtest"
+Shards = 32
+
+CacheMessages = false
+CacheBlocks = true
+RebroadcastCommit = true
+TrackPeers = false
+
+NotaryGroupConfig = "./wasmdocker.toml"
+WebsocketPort = 50000
+
+[Storage]
+Kind = "memory"

--- a/wasmtupelo/docker-compose.yml
+++ b/wasmtupelo/docker-compose.yml
@@ -43,6 +43,12 @@ services:
         ipv4_address: 172.16.246.11
     ports:
       - "50000:50000"
+ 
+  community2:
+    image: quorumcontrol/community:master
+    volumes:
+      - ./configs:/configs
+    command: ["-c", "/configs/community2.toml"]
 
 networks:
   default:


### PR DESCRIPTION
This adds a second community because wasm does interact in a different way with multiple sources of truth with differing communities and it's fairly low overhead, so it makes sense to simulate that.