### PR TITLE
touchups to the messaging interface

### DIFF
--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -68,9 +68,9 @@ export namespace Community {
 
 // @beta
 export class CommunityMessenger {
-    constructor(name: string, shards: number, key: EcdsaKey, localIdentifier: string, pubsub: IPubSub);
+    constructor(name: string, shards: number, key: EcdsaKey, localIdentifier: Uint8Array, pubsub: IPubSub);
     // (undocumented)
-    localIdentifier: string;
+    localIdentifier: Uint8Array;
     // (undocumented)
     name: string;
     // (undocumented)

--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -221,7 +221,7 @@ export namespace Community {
      * setDefault allows you to set a community you control so that when code calls Community.getDefault() it
      * returns this community. This is useful in situations like local testing, where your test harness can
      * point the code at a local community.
-     * @param community - the {@link Commmunity} to set as default 
+     * @param community - the {@link Community} to set as default 
      * @public
      */
     export async function setDefault(community:Community) {

--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -89,7 +89,7 @@ export class Community extends EventEmitter {
      * around getting the current state, and then casting the tip, etc.
      * @param did - The DID of the ChainTree
      */
-    async getTip(did: string) {
+    async getTip(did: string):Promise<CID> {
         const state = await this.getCurrentState(did)
         const sig = state.getSignature()
         if (sig == undefined) {

--- a/src/community/messaging.spec.ts
+++ b/src/community/messaging.spec.ts
@@ -39,8 +39,8 @@ describe("Community messaging", ()=> {
         const sender = await Community.freshLocalTestCommunity()
         const receiver = await Community.freshLocalTestCommunity()
 
-        let senderM = new CommunityMessenger("integrationtest", 32,senderKey, "testclient", sender.node.pubsub)
-        let receiverM = new CommunityMessenger("integrationtest", 32,receiverKey, "testclient", receiver.node.pubsub)
+        let senderM = new CommunityMessenger("integrationtest", 32,senderKey, Buffer.from("a:name:thatdidntworkbefore", 'utf8'), sender.node.pubsub)
+        let receiverM = new CommunityMessenger("integrationtest", 32,receiverKey, Buffer.from("a:different:name", 'utf8'), receiver.node.pubsub)
 
         const topic = 'agreattopictolistento'
         await receiverM.subscribe(topic, (env:Envelope)=> {

--- a/src/community/messaging.ts
+++ b/src/community/messaging.ts
@@ -17,12 +17,12 @@ const log = debug("community:messaging")
  */
 export class CommunityMessenger {
     name:string
-    localIdentifier:string
+    localIdentifier:Uint8Array
     private key:EcdsaKey
     private shards:number
     private pubsub:IPubSub
 
-    constructor(name:string, shards:number, key:EcdsaKey, localIdentifier:string, pubsub:IPubSub) {
+    constructor(name:string, shards:number, key:EcdsaKey, localIdentifier:Uint8Array, pubsub:IPubSub) {
         this.name = name
         this.shards = shards
         this.pubsub = pubsub


### PR DESCRIPTION
Noticed that DIDs are trying to be base64d by protobuf for some reason (I think because of the ':'). This switches local identifier to match the protobuf

Also adds a type to the getTip method return.