### PR TITLE
go 1.13 WASM build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,12 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - uses: actions/setup-go@v1
-        with:
-          go-version: '1.13' # this should setup the GOPATH for the next step
       - run: cd wasmtupelo && docker-compose up -d
       - run: npm install
       - name: git setup
         run: scripts/ci-gitsetup.sh
       - name: build wasm and javascript
         env:
-          GOPATH: ${GOPATH}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: scripts/ci-build.sh
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13' # this should setup the GOPATH for the next step
       - run: cd wasmtupelo && docker-compose up -d
       - run: npm install
       - name: git setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         run: scripts/ci-gitsetup.sh
       - name: build wasm and javascript
         env:
+          GOPATH: ${GOPATH}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: scripts/ci-build.sh
       - run: npm test

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,5 @@ api-extractor.json
 docs
 build-docs.sh
 build.sh
+scripts
+builddocker

--- a/builddocker/Dockerfile
+++ b/builddocker/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.13-alpine
+
+RUN apk add --no-cache --update build-base git bash
+
+WORKDIR /app
+ENV GO111MODULE on

--- a/builddocker/docker-compose.yml
+++ b/builddocker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  builder:
+    build: .
+    volumes:
+      - ..:/app:delegated
+      - ./.tmp:/root/.cache:delegated
+      - ${GOPATH}/pkg/mod:/go/pkg/mod:delegated
+    command: /app/scripts/_docker-build.sh

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "./build.sh",
     "docs": "./build-docs.sh",
     "test": "mocha --exit -r ts-node/register src/*.spec.ts src/**/*.spec.ts",
-    "build:wasm": "cd ./tupelo-go-sdk/wasm && GOOS=js GOARCH=wasm go build -ldflags='-s -w' -o ../../src/js/go/tupelo.wasm"
+    "build:wasm": "scripts/build-wasm.sh"
   },
   "author": "",
   "license": "rights reserved.",

--- a/scripts/_docker-build.sh
+++ b/scripts/_docker-build.sh
@@ -5,4 +5,4 @@
 set -x
 
 cd /app/tupelo-go-sdk/wasm
-GOOS=js GOARCH=wasm go build mod=vendor -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}" -ldflags='-s -w' -o /app/src/js/go/tupelo.wasm
+GOOS=js GOARCH=wasm go build -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}" -ldflags='-s -w' -o /app/src/js/go/tupelo.wasm

--- a/scripts/_docker-build.sh
+++ b/scripts/_docker-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# This file should be executed INSIDE of docker
+
+set -x
+
+cd /app/tupelo-go-sdk/wasm
+GOOS=js GOARCH=wasm go build -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}" -ldflags='-s -w' -o /app/src/js/go/tupelo.wasm

--- a/scripts/_docker-build.sh
+++ b/scripts/_docker-build.sh
@@ -5,4 +5,4 @@
 set -x
 
 cd /app/tupelo-go-sdk/wasm
-GOOS=js GOARCH=wasm go build -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}" -ldflags='-s -w' -o /app/src/js/go/tupelo.wasm
+GOOS=js GOARCH=wasm go build mod=vendor -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}" -ldflags='-s -w' -o /app/src/js/go/tupelo.wasm

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x -e
+
+pushd $(dirname "$0")/../tupelo-go-sdk
+trap popd EXIT
+
+make vendor
+
+popd
+pushd $(dirname "$0")/../builddocker
+
+docker-compose run --rm builder

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -5,7 +5,7 @@ set -x -e
 pushd $(dirname "$0")/../tupelo-go-sdk
 trap popd EXIT
 
-make vendor
+go mod download
 
 popd
 pushd $(dirname "$0")/../builddocker

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -5,6 +5,8 @@ set -x -e
 pushd $(dirname "$0")/../tupelo-go-sdk
 trap popd EXIT
 
+export GOPATH=`go env GOPATH`
+
 go mod download
 
 popd

--- a/src/js/go/index.js
+++ b/src/js/go/index.js
@@ -15,7 +15,8 @@ const log = require('debug')('gowasm');
         throw new Error("cannot export Go (neither global, window nor self is defined)");
     }
 
-    var encoder,decoder;
+
+    var encoder, decoder;
 
     // Map web browser API and Node.js API to a single common API (preferring web standards over Node.js API).
     const isNodeJS = global.process && global.process.title.indexOf("node") !== -1;
@@ -229,7 +230,7 @@ const log = require('debug')('gowasm');
                         const fd = getInt64(sp + 8);
                         const p = getInt64(sp + 16);
                         const n = mem().getInt32(sp + 24, true);
-                        global.fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+                        fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
                     },
 
                     // func nanotime() int64
@@ -249,7 +250,15 @@ const log = require('debug')('gowasm');
                         const id = this._nextCallbackTimeoutID;
                         this._nextCallbackTimeoutID++;
                         this._scheduledTimeouts.set(id, setTimeout(
-                            () => { this._resume(); },
+                            () => {
+                                this._resume();
+                                while (this._scheduledTimeouts.has(id)) {
+                                    // for some reason Go failed to register the timeout event, log and try again
+                                    // (temporary workaround for https://github.com/golang/go/issues/28975)
+                                    console.warn("scheduleTimeoutEvent: missed timeout event");
+                                    this._resume();
+                                }
+                            },
                             getInt64(sp + 8) + 1, // setTimeout has been seen to fire up to 1 millisecond early
                         ));
                         mem().setInt32(sp + 16, id, true);
@@ -363,6 +372,34 @@ const log = require('debug')('gowasm');
                         mem().setUint8(sp + 24, loadValue(sp + 8) instanceof loadValue(sp + 16));
                     },
 
+                    // func copyBytesToGo(dst []byte, src ref) (int, bool)
+                    "syscall/js.copyBytesToGo": (sp) => {
+                        const dst = loadSlice(sp + 8);
+                        const src = loadValue(sp + 32);
+                        if (!(src instanceof Uint8Array)) {
+                            mem().setUint8(sp + 48, 0);
+                            return;
+                        }
+                        const toCopy = src.subarray(0, dst.length);
+                        dst.set(toCopy);
+                        setInt64(sp + 40, toCopy.length);
+                        mem().setUint8(sp + 48, 1);
+                    },
+
+                    // func copyBytesToJS(dst ref, src []byte) (int, bool)
+                    "syscall/js.copyBytesToJS": (sp) => {
+                        const dst = loadValue(sp + 8);
+                        const src = loadSlice(sp + 16);
+                        if (!(dst instanceof Uint8Array)) {
+                            mem().setUint8(sp + 48, 0);
+                            return;
+                        }
+                        const toCopy = src.subarray(0, dst.length);
+                        dst.set(toCopy);
+                        setInt64(sp + 40, toCopy.length);
+                        mem().setUint8(sp + 48, 1);
+                    },
+
                     "debug": (value) => {
                         console.log(value);
                     },
@@ -379,11 +416,11 @@ const log = require('debug')('gowasm');
                 true,
                 false,
                 global,
-                this._inst.exports.mem,
                 this,
             ];
             this._refs = new Map();
             this.exited = false;
+
 
             const mem = new DataView(this._inst.exports.mem.buffer)
 
@@ -463,13 +500,13 @@ const runner = {
 
         const go = new Go();
         go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);
-        // go.exit = process.exit;
+
         let result
 
         if (isNodeJS) {
             const wasmBits = global.fs.readFileSync(Go.wasmPath)
             result = await WebAssembly.instantiate(wasmBits, go.importObject)
-        
+
             process.on("exit", (code) => { // Node.js exits if no event handler is pending
                 Go.exit();
                 if (code === 0 && !go.exited) {

--- a/src/js/go/index.js
+++ b/src/js/go/index.js
@@ -230,7 +230,7 @@ const log = require('debug')('gowasm');
                         const fd = getInt64(sp + 8);
                         const p = getInt64(sp + 16);
                         const n = mem().getInt32(sp + 24, true);
-                        fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+                        global.fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
                     },
 
                     // func nanotime() int64


### PR DESCRIPTION
This moves the wasm build into docker - write now pointing at https://github.com/quorumcontrol/tupelo-go-sdk/pull/129

This makes a slightly smaller wasm file (32MB) and should improve memory usage (due to the byte copying)