### PR TITLE
add pid and title to browser env

### DIFF
--- a/src/js/go/index.js
+++ b/src/js/go/index.js
@@ -44,6 +44,10 @@ const log = require('debug')('gowasm');
     } else {
         log('browser running');
         global.Buffer = require('buffer').Buffer;
+        global.process = {
+            pid: 2,
+            title: window.navigator.userAgent
+        };
         let outputBuf = "";
         global.fs = {
             constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1 }, // unused


### PR DESCRIPTION
lost this along the way somewhere, but in the browser one needs a pid and title because our logging library uses those. Go seems to have left that out of their default by accident.

We *used* to have this code somewhere, but I must have accidentally ripped it out somewhere along the line.