### PR TITLE
cleanup handling of calling getDefault multiple times

### DIFF
--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -214,7 +214,7 @@ export namespace Community {
      * @param repo - (optional) - a {@link Repo} object (wrapper around an IPFS repo).
      * @public
     */
-    export async function getDefault(repo?: Repo) {
+    export function getDefault(repo?: Repo) {
         return _getDefault(repo)
     }
 
@@ -225,7 +225,7 @@ export namespace Community {
      * @param community - the {@link Community} to set as default 
      * @public
      */
-    export async function setDefault(community:Community) {
+    export function setDefault(community:Community) {
         return _setDefault(community);
     }
 

--- a/src/community/default.integration.ts
+++ b/src/community/default.integration.ts
@@ -21,4 +21,10 @@ describe('default community', ()=> {
         expect(defaultC).to.equal(c)
         c.stop()
     })
+    it('always gives you the same community', async ()=> {
+        let cp1 = Community.getDefault()
+        let cp2 = Community.getDefault()
+        let [c1,c2] = await Promise.all([cp1,cp2])
+        expect(c1).to.equal(c2)
+    })
 })

--- a/src/community/default.ts
+++ b/src/community/default.ts
@@ -59,26 +59,25 @@ DestKeyHex = "0x046d0293103d8975b174bbe5752a958b13c3f937ae67b24027b6cafb780b8d88
  */
 export const defaultNotaryGroup = tomlToNotaryGroup(testNetToml)
 
-let _defaultCommunity: Community|undefined
+let _defaultCommunity: Promise<Community>|undefined
 
 /**
  * 
  * @internal
  */
 export function _setDefault(c:Community) {
-    _defaultCommunity = c
+    _defaultCommunity = Promise.resolve(c)
 }
 
 /**
  * 
  * @internal
  */
-export const _getDefault = async (repo?:Repo): Promise<Community> => {
-    return new Promise(async (resolve,reject) => {    
-        if (_defaultCommunity !== undefined) {
-            resolve(_defaultCommunity.start())
-        }
-        
+export const _getDefault = (repo?:Repo): Promise<Community> => {
+    if (_defaultCommunity !== undefined) {
+        return _defaultCommunity
+    }
+    _defaultCommunity = new Promise(async (resolve,reject) => {    
         if (repo == undefined) {
             repo = new Repo("default")
             await repo.init({})
@@ -92,7 +91,6 @@ export const _getDefault = async (repo?:Repo): Promise<Community> => {
         })
 
         const c = new Community(node, defaultNotaryGroup, repo.repo)
-        _defaultCommunity = c
     
         node.start(async () => {
             log("node started");
@@ -104,5 +102,5 @@ export const _getDefault = async (repo?:Repo): Promise<Community> => {
             _defaultCommunity = undefined
         })
     })
-    
+    return _defaultCommunity
 }


### PR DESCRIPTION
Noticed by a community member, sometimes calling getDefault was returning different communities. I believe that was due to the differing async calls here. This cleans that up so that the check and return is always happening in a sync call and not in promises.