### PR TITLE
Bump version to v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "0.0.13",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "0.0.13",
+  "version": "0.5.0",
   "description": "The JavaScript SDK for interacting with the Tupelo network",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Also examples have `package.json` and `package-lock.json` pegged to `v0.0.13` - bumping those requires npm publish, which should come after doing the release & pr here. Should we change those to be `"tupelo-wasm-sdk": "../../"`? Downside there is someone couldn't checkout this repo, move the examples folder to somewhere else, and try and run