### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish NPM package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: cd wasmtupelo && docker-compose up -d
+      - run: npm install
+      - name: git setup
+        run: scripts/ci-gitsetup.sh
+      - name: build wasm and javascript
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: scripts/ci-build.sh
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: version check
+        run: scripts/ci-release-ver-check.sh
       - run: cd wasmtupelo && docker-compose up -d
       - run: npm install
       - name: git setup

--- a/scripts/ci-release-ver-check.sh
+++ b/scripts/ci-release-ver-check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+release_ver=$(echo "$GITHUB_REF" | rev | cut -d / -f 1 | rev | grep -o -P "\d+\.\d+\.\d+")
+package_ver=$(npm list tupelo-wasm-sdk | grep -o -P "tupelo-wasm-sdk@\d+\.\d+\.\d+" | grep -o -P "\d+\.\d+\.\d+")
+
+if [ "$release_ver" -ne "$package_ver" ]; then
+  echo "ERROR: mismatched versions"
+  echo " > release version $release_ver"
+  echo " > package version $package_ver"
+  exit 1
+fi


### PR DESCRIPTION
Publish releases to npm whenever a new github release is published. Decided to go ahead and run tests as preflight to publishing