### PR TITLE
fix GetTip panic by avoiding retrys on PlayTransactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "0.5.0",
+  "version": "0.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "The JavaScript SDK for interacting with the Tupelo network",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Updates `tupelo-go-sdk` which sets `MaxPlayTransactionsAttempts` to 1 for wasm, avoiding the unsupported `GetTip` call in the retry loop of `PlayTransactions`