### PR TITLE
expose a community from toml builder

### DIFF
--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -63,6 +63,7 @@ export class Community extends EventEmitter {
 // @public (undocumented)
 export namespace Community {
     export function freshLocalTestCommunity(repo?: Repo): Promise<Community>;
+    export function fromNotaryGroupToml(tomlString: string, repo?: Repo): Promise<Community>;
     export function getDefault(repo?: Repo): Promise<Community>;
     export function setDefault(community: Community): void;
 }
@@ -192,7 +193,7 @@ export interface IDagStore {
     // (undocumented)
     get(cid: CID_2): Promise<Object>;
     // Warning: (ae-forgotten-export) The symbol "IExtendedDagStoreIterator" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     resolve(cid: CID_2, path: string): IExtendedDagStoreIterator;
 }
@@ -286,7 +287,7 @@ export class Repo {
     // (undocumented)
     open(): Promise<any>;
     // Warning: (ae-forgotten-export) The symbol "IKey" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     put(key: IKey, val: Uint8Array): Promise<any>;
     // (undocumented)
@@ -300,7 +301,7 @@ export interface RepoOpts {
     // (undocumented)
     lock: string;
     // Warning: (ae-forgotten-export) The symbol "IStorageBackendOpts" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     storageBackends: IStorageBackendOpts;
 }
@@ -326,7 +327,7 @@ export namespace Tupelo {
     // (undocumented)
     export function generateKey(): Promise<Uint8Array[]>;
     // Warning: (ae-forgotten-export) The symbol "IGetCurrentStateOptions" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     export function getCurrentState(opts: IGetCurrentStateOptions): Promise<CurrentState>;
     // (undocumented)
@@ -342,7 +343,7 @@ export namespace Tupelo {
     // (undocumented)
     export function playTransactions(publisher: IPubSub, notaryGroup: NotaryGroup, tree: ChainTree, transactions: Transaction[]): Promise<CurrentState>;
     // Warning: (ae-forgotten-export) The symbol "ITransactionPayloadOpts" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     export function tokenPayloadForTransaction(opts: ITransactionPayloadOpts): Promise<TokenPayload>;
     export function verifyCurrentState(notaryGroup: NotaryGroup, state: CurrentState): Promise<boolean>;

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -14,7 +14,8 @@ import { Transaction, SetDataPayload } from 'tupelo-messages/transactions/transa
 import Tupelo from '../tupelo';
 import debug from 'debug';
 import { CurrentState } from 'tupelo-messages/signatures/signatures_pb';
-import { testNotaryGroup } from '../constants.spec'
+import { testNotaryGroup, testNotaryGroupTOML } from '../constants.spec'
+import { defaultNotaryGroup } from './default';
 
 const log = debug("communityspec")
 
@@ -220,5 +221,24 @@ describe('Community', () => {
     p.then(() => { c.stop() })
     return p
   }).timeout(10000)
+
+  it('can create a community from a toml config', async ()=> {
+    const repo = new Repo('test', {
+      lock: 'memory',
+      storageBackends: {
+        root: MemoryDatastore,
+        blocks: MemoryDatastore,
+        keys: MemoryDatastore,
+        datastore: MemoryDatastore
+      }
+    })
+    await repo.init({})
+    await repo.open()
+
+    const c = await Community.fromNotaryGroupToml(testNotaryGroupTOML, repo)
+    expect(c.group.getId()).to.equal('tupelolocal')
+
+    c.stop()
+  })
 
 })

--- a/src/constants.spec.ts
+++ b/src/constants.spec.ts
@@ -10,4 +10,6 @@ if (fs.existsSync("/tupelo-local/config/notarygroup.toml")) {
   tomlFile = path.join(__dirname, '../notarygroup.toml')
 }
 
-export const testNotaryGroup = tomlToNotaryGroup(fs.readFileSync(tomlFile).toString())
+export const testNotaryGroupTOML = fs.readFileSync(tomlFile).toString()
+
+export const testNotaryGroup = tomlToNotaryGroup(testNotaryGroupTOML)


### PR DESCRIPTION
Noticed a lot of boiler plate when you just want to connect to a different notary group (h/t @brandonwestcott ). This PR adds a `Community.fromNotaryGroupToml` method that takes a toml config and gives you back a connected community (and takes an optional repo).