### PR TITLE
symlink to the built tupelo.wasm which is necessary in the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-tupelo.wasm
+src/js/go/tupelo.wasm
 node_modules
 lib // ignore the generated code
 .tmp

--- a/browsertest/tupelo.wasm
+++ b/browsertest/tupelo.wasm
@@ -1,0 +1,1 @@
+../src/js/go/tupelo.wasm


### PR DESCRIPTION
forgot to symlink the tupelo.wasm into the browser tests to make sure it's available. I'll keep my clownshoes ChainTree for this one.