### PR TITLE
allows signing/verifying of arbitrary messages

### DIFF
--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -10,6 +10,7 @@ import EventEmitter from 'events';
 import { NotaryGroup } from 'tupelo-messages/config/config_pb';
 import { NotaryGroup as NotaryGroup_2 } from 'tupelo-messages';
 import OldCId from 'cids';
+import { Signature } from 'tupelo-messages/signatures/signatures_pb';
 import { TokenPayload } from 'tupelo-messages/transactions/transactions_pb';
 import { Transaction } from 'tupelo-messages';
 import { Transaction as Transaction_2 } from 'tupelo-messages/transactions/transactions_pb';
@@ -104,16 +105,20 @@ export const defaultNotaryGroup: import("tupelo-messages").NotaryGroup;
 // @public
 export class EcdsaKey {
     constructor(publicKeyBits: Uint8Array, privateKeyBits?: Uint8Array);
+    address(): Promise<string>;
     // (undocumented)
     static fromBytes: (bytes: Uint8Array) => Promise<EcdsaKey>;
     static generate: () => Promise<EcdsaKey>;
-    // (undocumented)
+    // @deprecated
     keyAddr(): Promise<string>;
     static passPhraseKey: (phrase: Uint8Array, salt: Uint8Array) => Promise<EcdsaKey>;
     // (undocumented)
     privateKey?: Uint8Array;
     // (undocumented)
     publicKey: Uint8Array;
+    signMessage(msg: Uint8Array): Promise<Signature>;
+    toDid(): Promise<string>;
+    verifyMessage(msg: Uint8Array, sig: Signature): Promise<boolean>;
 }
 
 // @public
@@ -348,11 +353,13 @@ export namespace Tupelo {
     export function passPhraseKey(phrase: Uint8Array, salt: Uint8Array): Promise<Uint8Array[]>;
     // (undocumented)
     export function playTransactions(publisher: IPubSub, notaryGroup: NotaryGroup, tree: ChainTree, transactions: Transaction[]): Promise<TreeState>;
+    export function signMessage(key: EcdsaKey, message: Uint8Array): Promise<Signature>;
     // Warning: (ae-forgotten-export) The symbol "ITransactionPayloadOpts" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     export function tokenPayloadForTransaction(opts: ITransactionPayloadOpts): Promise<TokenPayload>;
     export function verifyCurrentState(notaryGroup: NotaryGroup, state: TreeState): Promise<boolean>;
+    export function verifyMessage(address: string, message: Uint8Array, signature: Signature): Promise<boolean>;
 }
 
 // @public

--- a/src/crypto.spec.ts
+++ b/src/crypto.spec.ts
@@ -23,4 +23,25 @@ describe('EcdsaKeys', ()=> {
             expect(key.privateKey).to.have.length(32)
         }
     })
+
+    it('signs and verifies messages', async ()=> {
+        const key = await EcdsaKey.generate()    
+        const message = Buffer.from("test message")
+    
+        const sig = await key.signMessage(message)
+    
+        let verified = await key.verifyMessage(message, sig)
+        expect(verified).to.be.true
+
+        const badMessage = Buffer.from("invalid")
+        try {
+            verified = await key.verifyMessage(badMessage, sig)
+            expect(verified).to.be.false
+        } catch(e) {
+            expect(e).to.not.be.null
+        }
+    
+
+      })
+
 })

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,4 +1,5 @@
 import {Tupelo} from './tupelo'
+import { Signature } from 'tupelo-messages/signatures/signatures_pb'
 
 /**
  * EcdsaKey defines the public/private key-pairs used to interact with Tupelo.
@@ -37,7 +38,46 @@ export class EcdsaKey {
         this.privateKey = privateKeyBits
     }
 
-    async keyAddr() {
+    /**
+     * Returns the address of the public key (ethereum address format)
+     * @public
+     */
+    async address() {
+        return Tupelo.ecdsaPubkeyToAddress(this.publicKey)
+    }
+
+    /**
+     * Returns the DID generated from the public key address
+     * @public
+     */
+    async toDid() {
         return Tupelo.ecdsaPubkeyToDid(this.publicKey)
+    }
+
+    /**
+     * Signs an arbitrary byte message and returns a Signature object
+     * @param msg - the message to sign
+     * @public
+     */
+    async signMessage(msg:Uint8Array) {
+        return Tupelo.signMessage(this, msg)
+    }
+
+    /**
+     * Given a signature, make sure that it is valid for this key
+     * @param msg - the message to sign
+     * @param sig - the signature to verify
+     * @public
+     */
+    async verifyMessage(msg:Uint8Array, sig:Signature) {
+        return Tupelo.verifyMessage((await this.address()), msg, sig)
+    }
+
+    /**
+     * deprecated use address() or toDid()
+     * @deprecated
+     */
+    async keyAddr() {
+        return this.toDid()
     }
 }

--- a/src/tupelo.spec.ts
+++ b/src/tupelo.spec.ts
@@ -166,4 +166,16 @@ describe('Tupelo', () => {
     return p
   })
 
+  it('signs and verifies messages', async ()=> {
+    const key = await EcdsaKey.generate()
+    const addr = await Tupelo.ecdsaPubkeyToAddress(key.publicKey)
+
+    const message = Buffer.from("test message")
+
+    const sig = await Tupelo.signMessage(key, message)
+
+    const verified = await Tupelo.verifyMessage(addr, message, sig)
+    expect(verified).to.be.true
+  })
+
 })

--- a/src/tupelo.ts
+++ b/src/tupelo.ts
@@ -183,6 +183,12 @@ export namespace Tupelo {
         return tw.newEmptyTree(store, publicKey)
     }
 
+    /**
+     * signMessage allows an EcdsaKey to sign an arbitrary message
+     * @param key - the EcdsaKey to sign the message (must have a privateKey)
+     * @param message - the message to sign (arbitrary Uint8Arry/Buffer of bytes)
+     * @public
+     */
     export async function signMessage(key:EcdsaKey, message:Uint8Array):Promise<Signature> {
         if (key.privateKey === undefined) {
             throw new Error("key must contain a privat key to sign messages")
@@ -196,6 +202,13 @@ export namespace Tupelo {
         }
     }
 
+    /**
+     * verifyMessage is the recipricol of {@link signMessage}, it verifies that a signature is valid.
+     * @param address - the string address to verify against ( see {@link ecdsaPubkeyToAddress} )
+     * @param message - the message to verify ( see {@link signMessage} )
+     * @param signature - the {@link Signature} object to verify
+     * @public
+     */
     export async function verifyMessage(address:string, message:Uint8Array, signature:Signature):Promise<boolean> {
         const tw = await TupeloWasm.get()
         try {

--- a/src/tupelo.ts
+++ b/src/tupelo.ts
@@ -92,6 +92,12 @@ class UnderlyingWasm {
     verifyCurrentState(notaryGroupBytes:Uint8Array,currStateBytes:Uint8Array):Promise<boolean>{
         return new Promise<boolean>((res, rej) => { }) // replaced by wasm
     }
+    signMessage(privateKey:Uint8Array, message:Uint8Array):Promise<Uint8Array> {
+        return new Promise<Uint8Array>((res, rej) => { }) // replaced by wasm
+    }
+    verifyMessage(addr:string, message:Uint8Array, sigBits:Uint8Array):Promise<boolean> {
+        return new Promise<boolean>((res, rej) => { }) // replaced by wasm
+    }
 }
 
 namespace TupeloWasm {
@@ -175,6 +181,28 @@ export namespace Tupelo {
         logger("newEmptyTree")
         const tw = await TupeloWasm.get()
         return tw.newEmptyTree(store, publicKey)
+    }
+
+    export async function signMessage(key:EcdsaKey, message:Uint8Array):Promise<Signature> {
+        if (key.privateKey === undefined) {
+            throw new Error("key must contain a privat key to sign messages")
+        }
+        const tw = await TupeloWasm.get()
+        try {
+            const sigBits = await tw.signMessage(key.privateKey, message)
+            return Signature.deserializeBinary(sigBits)
+        } catch(e) {
+            throw e
+        }
+    }
+
+    export async function verifyMessage(address:string, message:Uint8Array, signature:Signature):Promise<boolean> {
+        const tw = await TupeloWasm.get()
+        try {
+            return await tw.verifyMessage(address, message, signature.serializeBinary())
+        } catch(e) {
+            throw e
+        }
     }
 
     export async function tokenPayloadForTransaction(opts:ITransactionPayloadOpts):Promise<TokenPayload> {


### PR DESCRIPTION
This branch uses the https://github.com/quorumcontrol/tupelo-go-sdk/pull/157/files branch of tupelo-go-sdk and allows an EcdsaKey to generate a signature