### PR TITLE
release bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,6 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: scripts/ci-build.sh
       - run: npm run test-suite
-      - run: npm publish
+      - run: npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,6 @@ build-docs.sh
 build.sh
 scripts
 builddocker
+browsertest
+Dockerfile
+.github

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "0.5.12",
+  "version": "2.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "2.0.0-pre",
+  "version": "2.0.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "2.0.0-pre",
+  "version": "2.0.1-pre",
   "description": "The JavaScript SDK for interacting with the Tupelo network",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-wasm-sdk",
-  "version": "0.5.12",
+  "version": "2.0.0-pre",
   "description": "The JavaScript SDK for interacting with the Tupelo network",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
in attempting to publish a pre-release I accidentally published the new wasm-sdk out to latest and required doing an emergency release of v0.5.15 (same as v0.5.14) in order to overwrite (unpublish didn't work).

This bumps this up to the current release (2.0.0-pre) and also adds the "next" tag for now when releasing until tupelo is also released with a testnet (at which point we should remove next)... but adding next lets us do the normal release path through github for now while not auto-upgrading our builders.