### PR TITLE
upgrade tupelo-messages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,6 @@
 node_modules
 /examples
 /temp
+browsertest
+dist
+lib

--- a/package-lock.json
+++ b/package-lock.json
@@ -3710,9 +3710,9 @@
       }
     },
     "tupelo-messages": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tupelo-messages/-/tupelo-messages-2.0.2.tgz",
-      "integrity": "sha512-5LQ8UyHHMcXlpis5P1xqBfBBy/gAYzt6qLTwjx3NGRvWb6vv1MQ76tKNZ9cUXmHXx6V6vsfqjoMoPqAUAIp7pA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tupelo-messages/-/tupelo-messages-2.1.1.tgz",
+      "integrity": "sha512-pFWPKDcScsvq4k2Bs+3Klh6nsOonTCjlL5iHQc6JUovhwA5DJXV6/dG08IDGlYa2BksUldvzj9Ne/oBnwJdvGA==",
       "requires": {
         "@types/google-protobuf": "^3.7.1",
         "@types/protobufjs": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pull-mplex": "^0.1.2",
     "pull-ws": "^3.3.2",
     "toml": "^3.0.0",
-    "tupelo-messages": "^2.0.2",
+    "tupelo-messages": "^2.1.1",
     "util": "^0.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
upgrades messages to 2.1.1 - also adds a few more thing to the .dockerignore