### PR TITLE
Fix browsertests for remote g4 net

### DIFF
--- a/browsertest/readme.md
+++ b/browsertest/readme.md
@@ -7,3 +7,9 @@ Run: `npm run dev` (from the browsertest directory) and then visit http://localh
 You need to have a local tupelo running... `docker-compose up tupelo` will do that for you from the main directory (`../` from this directory).
 
 The tests use Parcel to compile and serve the HTML and the mocha browser runner/css to display results.
+
+## Logging / Debugging
+
+Run `npm run dev` with ` DEBUG=` environment variable set to the names of the various debug namespaces in this project. Additionally, using `DEBUG=go` will turn on all the wasm / tupelo-go-sdk logs. The following is a reasonably verbose output:
+
+`DEBUG=community,tupelo,go npm run dev`

--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -15,7 +15,7 @@ import { Transaction } from 'tupelo-messages';
 import { Transaction as Transaction_2 } from 'tupelo-messages/transactions/transactions_pb';
 
 // @public
-export function afterTwoPeersConnected(node: IP2PNode): Promise<void>;
+export function afterThreePeersConnected(node: IP2PNode): Promise<void>;
 
 // @public
 export class ChainTree extends Dag {

--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -60,6 +60,7 @@ export class Community extends EventEmitter {
 
 // @public (undocumented)
 export namespace Community {
+    export function fromNotaryGroup(notaryGroup: NotaryGroup_2, repo?: Repo): Promise<Community>;
     export function fromNotaryGroupToml(tomlString: string, repo?: Repo): Promise<Community>;
     export function getDefault(repo?: Repo): Promise<Community>;
     export function setDefault(community: Community): void;

--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -149,13 +149,13 @@ export class Community extends EventEmitter {
  * This waits until the libp2p node has connected to two peers
  * @private
  */
-export function afterTwoPeersConnected(node:IP2PNode):Promise<void> {
+export function afterThreePeersConnected(node:IP2PNode):Promise<void> {
     return new Promise((resolve) => {
         let connectCount = 0
         const onConnect = async ()=> {
             debugLog("peer connected: ", connectCount)
             connectCount++
-            if (connectCount >= 2) {
+            if (connectCount >= 3) {
                 node.off('peer:connect', onConnect)
                 resolve()
             }
@@ -220,7 +220,7 @@ export namespace Community {
                 }
             }
 
-            afterTwoPeersConnected(node).then(async ()=> {
+            afterThreePeersConnected(node).then(async ()=> {
                 res(await c.start())
             })
 

--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -190,39 +190,44 @@ export namespace Community {
     }
 
     /**
-     * fromNotaryGroupToml creates a community from a notary grou TOML string with no boiler plate around
-     * creating a new libp2p node and only optionally requires a repo (a new repo will be created if one isn't passed in)
+     * fromNotaryGroup creates a community from a notary group TOML string without requiring boiler plate code for 
+     * creating a new libp2p node. repo argument is optional and will create one if not specified.
      * @param tomlString - the TOML for the notary group
      * @param repo - (optional) the repo to use for this notary group. Will default to an ondisk repo named after the notary group
      */
     export function fromNotaryGroupToml(tomlString: string, repo?:Repo):Promise<Community> {
+        const ng = tomlToNotaryGroup(tomlString)
+        return fromNotaryGroup(ng, repo)
+    }
+
+    /**
+     * fromNotaryGroup creates a community from a NotaryGroup without requiring boiler plate code for 
+     * creating a new libp2p node. repo argument is optional and will create one if not specified.
+     * @param notaryGroup - the notaryGroup
+     * @param repo - (optional) the repo to use for this notary group. Will default to an ondisk repo named after the notary group
+     */
+    export function fromNotaryGroup(notaryGroup: NotaryGroup, repo?:Repo):Promise<Community> {
         return new Promise(async (res,rej)=> {
-            const ng = tomlToNotaryGroup(tomlString)
-            try {
-                const node = await p2p.createNode({ bootstrapAddresses: ng.getBootstrapAddressesList() });
+            const node = await p2p.createNode({ bootstrapAddresses: notaryGroup.getBootstrapAddressesList() });
 
-                if (repo == undefined) {
-                    repo = new Repo(ng.getId())
-                    try {
-                        await repo.init({})
-                        await repo.open()
-                    } catch(e) {
-                        rej(e)
-                    }
+            if (repo == undefined) {
+                repo = new Repo(notaryGroup.getId())
+                try {
+                    await repo.init({})
+                    await repo.open()
+                } catch(e) {
+                    rej(e)
                 }
-
-                afterTwoPeersConnected(node).then(async ()=> {
-                    res(await c.start())
-                })
-
-                const c = new Community(node, ng, repo.repo)
-                node.start(async ()=>{
-                   debugLog("p2p node started")
-                })
-            } catch(e) {
-                debugLog("error creating community: ", e)
-                rej(e)
             }
+
+            afterTwoPeersConnected(node).then(async ()=> {
+                res(await c.start())
+            })
+
+            const c = new Community(node, notaryGroup, repo.repo)
+            node.start(async ()=>{
+                debugLog("p2p node started")
+            })
         })
     }
 }

--- a/src/community/default.ts
+++ b/src/community/default.ts
@@ -1,4 +1,4 @@
-import { Community, afterTwoPeersConnected } from "./community";
+import { Community, afterThreePeersConnected } from "./community";
 import { tomlToNotaryGroup } from "../notarygroup";
 import Repo from "../repo";
 import { p2p } from "../node";
@@ -92,7 +92,7 @@ export const _getDefault = (repo?:Repo): Promise<Community> => {
 
         const c = new Community(node, defaultNotaryGroup, repo.repo)
     
-        afterTwoPeersConnected(node).then(()=> {
+        afterThreePeersConnected(node).then(()=> {
             resolve(c.start())
         })
 

--- a/src/js/go/index.js
+++ b/src/js/go/index.js
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 const log = require('debug')('gowasm');
+const golog = require('debug')('go');
 
 (() => {
     if (typeof global !== "undefined") {
@@ -56,6 +57,7 @@ const log = require('debug')('gowasm');
                 outputBuf += decoder.decode(buf);
                 const nl = outputBuf.lastIndexOf("\n");
                 if (nl != -1) {
+                    golog(outputBuf.substr(0, nl));
                     outputBuf = outputBuf.substr(nl + 1);
                 }
                 return buf.length;


### PR DESCRIPTION
This makes browser test actually use the peer connection waiting and hardcodes that wait to `3` for now.

I've started on replacing `afterThreePeersConnected ` with a `requirePeersConnected`, which will take a list of a peers and minimum number of connections instead. That was a little bit trickier than I have time for right now, so opening this as it gets the tests consistently passing.

Also clarifies and cleans up the logging / debugging a bit.