### PR TITLE
Remove TUPELO_VERSION from test-suite

### DIFF
--- a/scripts/test-suite.sh
+++ b/scripts/test-suite.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TUPELO_VERSION=master docker-compose -f docker-compose.yml -f docker-compose.test.yml up --force-recreate --abort-on-container-exit
+docker-compose -f docker-compose.yml -f docker-compose.test.yml up --force-recreate --abort-on-container-exit
 exitcode=$?
 docker-compose down --remove-orphans -v
 exit $exitcode


### PR DESCRIPTION
docker-compose already has this default, and removing allows tupelo version switched per script execution