### PR TITLE
Use discovery namespace from notary group

### DIFF
--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -168,6 +168,8 @@ export interface IDagStore {
 export interface INodeOptions {
     // (undocumented)
     bootstrapAddresses?: string[];
+    // (undocumented)
+    namespace?: string;
 }
 
 // @public

--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -10,12 +10,13 @@ import { NotaryGroup } from 'tupelo-messages/config/config_pb';
 import { NotaryGroup as NotaryGroup_2 } from 'tupelo-messages';
 import OldCId from 'cids';
 import { Proof } from 'tupelo-messages/gossip/gossip_pb';
+import { PublicKeySet } from 'tupelo-messages/config/config_pb';
 import { TokenPayload } from 'tupelo-messages/transactions/transactions_pb';
 import { Transaction } from 'tupelo-messages';
 import { Transaction as Transaction_2 } from 'tupelo-messages/transactions/transactions_pb';
 
 // @public
-export function afterThreePeersConnected(node: IP2PNode): Promise<void>;
+export function afterOneSignerConnected(node: IP2PNode, group: NotaryGroup_2): Promise<void>;
 
 // @public
 export class ChainTree extends Dag {
@@ -191,6 +192,14 @@ export interface IP2PNode {
     stop(): null;
 }
 
+// @public (undocumented)
+export interface IPeerId {
+    // (undocumented)
+    isEqual(other: IPeerId): boolean;
+    // (undocumented)
+    toB58String(): string;
+}
+
 // @public
 export interface IPubSub {
     // (undocumented)
@@ -231,10 +240,16 @@ export interface IResolveResponse {
 export const mintTokenTransaction: (name: string, amount: number) => Transaction_2;
 
 // @public (undocumented)
+export function notaryGroupToSignerPeerIds(ng: NotaryGroup): Promise<IPeerId[]>;
+
+// @public (undocumented)
 export namespace p2p {
     // (undocumented)
     export function createNode(opts: INodeOptions): Promise<IP2PNode>;
 }
+
+// @public
+export function publicKeySetToPeerId(set: PublicKeySet): Promise<IPeerId>;
 
 // @public (undocumented)
 export const receiveTokenTransaction: (sendId: string, tip: Uint8Array, proof: Proof, leaves: Uint8Array[]) => Transaction_2;

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -42,7 +42,10 @@ describe('Community', () => {
 
     const testNotaryGroup = (await Community.getDefault()).group
 
-    var node = await p2p.createNode({ bootstrapAddresses: testNotaryGroup.getBootstrapAddressesList() });
+    var node = await p2p.createNode({
+      namespace: testNotaryGroup.getId(),
+      bootstrapAddresses: testNotaryGroup.getBootstrapAddressesList()
+    })
 
     const c = new Community(node, testNotaryGroup, repo.repo)
 

--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -212,7 +212,10 @@ export namespace Community {
     export function fromNotaryGroup(notaryGroup: NotaryGroup, repo?:Repo):Promise<Community> {
 
         return new Promise(async (res,rej)=> {
-            const node = await p2p.createNode({ bootstrapAddresses: notaryGroup.getBootstrapAddressesList() });
+            const node = await p2p.createNode({
+                namespace: notaryGroup.getId(),
+                bootstrapAddresses: notaryGroup.getBootstrapAddressesList()
+            })
 
             if (repo == undefined) {
                 repo = new Repo(notaryGroup.getId())
@@ -224,11 +227,12 @@ export namespace Community {
                 }
             }
 
+            const c = new Community(node, notaryGroup, repo.repo)
+
             afterOneSignerConnected(node, notaryGroup).then(async ()=> {
                 res(await c.start())
             })
 
-            const c = new Community(node, notaryGroup, repo.repo)
             node.start(async ()=>{
                 debugLog("p2p node started")
             })

--- a/src/community/default.ts
+++ b/src/community/default.ts
@@ -84,7 +84,10 @@ export const _getDefault = (repo?:Repo): Promise<Community> => {
             await repo.open()
         }
 
-        const node = await p2p.createNode({ bootstrapAddresses: defaultNotaryGroup.getBootstrapAddressesList() });
+        const node = await p2p.createNode({
+            namespace: defaultNotaryGroup.getId(),
+            bootstrapAddresses: defaultNotaryGroup.getBootstrapAddressesList()
+        });
         node.on('error', (err: Error) => {
             console.error('p2p error: ', err)
             reject(err)

--- a/src/js/p2p/discovery.js
+++ b/src/js/p2p/discovery.js
@@ -51,6 +51,24 @@ class RoutingStub extends EventEmitter {
 }
 
 
+class NullDiscovery extends EventEmitter {
+    constructor() {
+        super()
+    }
+
+    start(callback) {
+        callback()
+    }
+
+    stop(callback) {
+        callback()
+    }
+
+    stub() {
+        return this;
+    }
+}
+
 class RoutingDiscovery extends EventEmitter {
     constructor(options) {
         super()
@@ -130,6 +148,8 @@ class RoutingDiscovery extends EventEmitter {
     }
 }
 
+module.exports.RoutingDiscovery = RoutingDiscovery
+module.exports.NullDiscovery = NullDiscovery
 
-exports = module.exports = RoutingDiscovery
+exports = module.exports
 exports.tag = 'routing'

--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -4,11 +4,15 @@ import 'mocha';
 import { p2p } from './node';
 
 describe('p2p', ()=> {
-    it('creates a node', async ()=> {
+    it('creates a node with namespace', async ()=> {
         let resolve:Function,reject:Function
         const p = new Promise((res,rej)=> { resolve = res, reject = rej})
 
-        var node = await p2p.createNode({bootstrapAddresses:["/ip4/172.16.246.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"]});
+        var node = await p2p.createNode({
+            namespace: "testing",
+            bootstrapAddresses:["/ip4/172.16.246.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"]
+        })
+
         expect(node).to.exist;
         node.start(()=> {
             node.stop();
@@ -16,7 +20,21 @@ describe('p2p', ()=> {
         });
         return p
     })
+
+    it('creates a node without namespace', async ()=> {
+        let resolve:Function,reject:Function
+        const p = new Promise((res,rej)=> { resolve = res, reject = rej})
+
+        var node = await p2p.createNode({
+            bootstrapAddresses:["/ip4/172.16.246.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"]
+        })
+
+        expect(node).to.exist;
+        node.start(()=> {
+            node.stop();
+            resolve()
+        });
+        return p
+    })
+
 })
-
-
-

--- a/src/node.ts
+++ b/src/node.ts
@@ -32,6 +32,7 @@ export interface IPubSubMessage {
  * @public
  */
 export interface INodeOptions {
+    namespace?:string
     bootstrapAddresses?:string[]
 }
 
@@ -46,6 +47,7 @@ export namespace p2p {
      */
     export async function createNode(opts:INodeOptions):Promise<IP2PNode> {
         return libp2p.CreateNode({
+            namespace: opts.namespace,
             config: {
                 peerDiscovery: {
                     bootstrap: {


### PR DESCRIPTION
This makes the RoutingDiscovery use the namespace specified in the NotaryGroup. One note, I made the `namespace` optional, defaulting to a noop / null router. Went back and forth if thats necessary interface though.