### PR TITLE
Use only WSS addrs in HTTPS

### DIFF
--- a/src/js/p2p/wss-peer-book.js
+++ b/src/js/p2p/wss-peer-book.js
@@ -1,0 +1,22 @@
+const PeerBook = require('peer-book')
+
+const WSS_PROTO_CODE = 478
+
+class WssPeerBook extends PeerBook {
+  // Filters out non WSS addrs
+  put (peerInfo, replace) {
+    let wssOnly = []
+
+    peerInfo.multiaddrs.forEach((ma) => {
+      if (ma.protoCodes().includes(WSS_PROTO_CODE)) {
+        wssOnly.push(ma)
+      }
+    })
+
+    peerInfo.multiaddrs.replace(peerInfo.multiaddrs.toArray(), wssOnly)
+
+    return super.put(peerInfo, replace)
+  }
+}
+
+module.exports = WssPeerBook

--- a/src/js/p2p/wss-peer-book.spec.ts
+++ b/src/js/p2p/wss-peer-book.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai'
+import 'mocha';
+
+const WssPeerBook = require('./wss-peer-book')
+const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
+
+describe('WssPeerBook', ()=> {
+  it('filters out non wss addrs from peers on .put', async ()=> {
+    const peerBook = new WssPeerBook()
+    const peerId = PeerId.createFromB58String("16Uiu2HAmJs2thyy5nDBiMZaR9DMmqpzfYZygoBdpxpkGxV6XGVYc")
+    const peerInfo = new PeerInfo(peerId)
+
+    peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0/ws')
+    peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0/wss')
+    peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
+    peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/0/ws')
+    peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/0/wss')
+    peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/0')
+
+    expect(peerInfo.multiaddrs.size).to.eql(6)
+    peerBook.put(peerInfo)
+
+    const storedPeerInfo = peerBook.get(peerId)
+    const filteredAddrs = storedPeerInfo.multiaddrs.toArray()
+
+    expect(filteredAddrs.length).to.eql(2)
+
+    expect(filteredAddrs[0].toString()).to.eq('/ip4/0.0.0.0/tcp/0/wss')
+    expect(filteredAddrs[1].toString()).to.eq('/ip4/127.0.0.1/tcp/0/wss')
+  })
+})


### PR DESCRIPTION
This updates the libp2p node to use only WSS addresses when running within the browser under https.