### PR TITLE
make tests work consistently

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - ./localtupelo/configs:/configs      
     command: ["node", "--config", "/configs/node1/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-warn}"]
+    ports:
+      - "50002:50002"
   
   node2:
     depends_on: 
@@ -43,6 +45,8 @@ services:
       - ./localtupelo/configs:/configs      
     command: ["node", "--config", "/configs/node2/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-warn}"]
+    ports:
+      - "50003:50003"
 
 networks:
   default:

--- a/localtupelo/configs/node1/config.toml
+++ b/localtupelo/configs/node1/config.toml
@@ -1,5 +1,5 @@
 NotaryGroupConfig = "../localdocker.toml"
-WebsocketPort = 50000
+WebsocketPort = 50002
 
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"

--- a/localtupelo/configs/node2/config.toml
+++ b/localtupelo/configs/node2/config.toml
@@ -1,5 +1,5 @@
 NotaryGroupConfig = "../localdocker.toml"
-WebsocketPort = 50000
+WebsocketPort = 50003
 
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"


### PR DESCRIPTION
Sometimes tests were failing on that first tupelo playtransaction - after debugging, it was only passing when the first connected peer was `node0` from docker-compose. Exposing the ports on the other nodes seems to make it consistently 💚 