### PR TITLE
support for conditions and preImage

### DIFF
--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -133,6 +133,14 @@ export interface IBlock {
 }
 
 // @public
+export interface IBlockOptions {
+    // (undocumented)
+    conditions?: string;
+    // (undocumented)
+    preImage?: string;
+}
+
+// @public
 export interface IBlockService {
     // (undocumented)
     delete(cid: CID_2): Promise<any>;
@@ -320,15 +328,16 @@ export namespace Tupelo {
     // (undocumented)
     export function getTip(did: string): Promise<Proof>;
     // (undocumented)
+    export function hash(bits: Uint8Array): Promise<Uint8Array>;
+    // (undocumented)
     export function keyFromPrivateBytes(bytes: Uint8Array): Promise<Uint8Array[]>;
     // (undocumented)
     export function newEmptyTree(store: IBlockService, publicKey: Uint8Array): Promise<CID_2>;
-    // (undocumented)
     export function ownershipToAddress(ownership: Ownership): Promise<string>;
     // (undocumented)
     export function passPhraseKey(phrase: Uint8Array, salt: Uint8Array): Promise<Uint8Array[]>;
     // (undocumented)
-    export function playTransactions(tree: ChainTree, transactions: Transaction[]): Promise<Proof>;
+    export function playTransactions(tree: ChainTree, transactions: Transaction[], options?: IBlockOptions): Promise<Proof>;
     // (undocumented)
     export function setLogLevel(name: string, level: string): Promise<void>;
     // (undocumented)

--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -9,7 +9,9 @@ import EventEmitter from 'events';
 import { NotaryGroup } from 'tupelo-messages/config/config_pb';
 import { NotaryGroup as NotaryGroup_2 } from 'tupelo-messages';
 import OldCId from 'cids';
+import { Ownership } from 'tupelo-messages/signatures/signatures_pb';
 import { Proof } from 'tupelo-messages/gossip/gossip_pb';
+import { PublicKey } from 'tupelo-messages/signatures/signatures_pb';
 import { PublicKeySet } from 'tupelo-messages/config/config_pb';
 import { TokenPayload } from 'tupelo-messages/transactions/transactions_pb';
 import { Transaction } from 'tupelo-messages';
@@ -103,6 +105,8 @@ export class EcdsaKey {
     // (undocumented)
     publicKey: Uint8Array;
     toDid(): Promise<string>;
+    // @internal
+    toPublicKeyPB(): PublicKey;
 }
 
 // @public
@@ -307,9 +311,9 @@ export function tomlToNotaryGroup(tomlString: string): NotaryGroup;
 
 // @public
 export namespace Tupelo {
-    // (undocumented)
+    // @deprecated (undocumented)
     export function ecdsaPubkeyToAddress(pubKey: Uint8Array): Promise<string>;
-    // (undocumented)
+    // @deprecated (undocumented)
     export function ecdsaPubkeyToDid(pubKey: Uint8Array): Promise<string>;
     // (undocumented)
     export function generateKey(): Promise<Uint8Array[]>;
@@ -319,6 +323,8 @@ export namespace Tupelo {
     export function keyFromPrivateBytes(bytes: Uint8Array): Promise<Uint8Array[]>;
     // (undocumented)
     export function newEmptyTree(store: IBlockService, publicKey: Uint8Array): Promise<CID_2>;
+    // (undocumented)
+    export function ownershipToAddress(ownership: Ownership): Promise<string>;
     // (undocumented)
     export function passPhraseKey(phrase: Uint8Array, salt: Uint8Array): Promise<Uint8Array[]>;
     // (undocumented)

--- a/src/crypto.spec.ts
+++ b/src/crypto.spec.ts
@@ -31,4 +31,19 @@ describe('EcdsaKeys', ()=> {
         expect(pb.getPublicKey_asU8()).to.equal(key.publicKey)
         expect(pb.getType()).to.equal(PublicKey.Type.KEYTYPESECP256K1)
     })
+
+    it('converts to an address', async ()=> {
+        const key = await EcdsaKey.generate()
+        const addr = await key.address()
+        expect(addr).to.have.length(42)
+    })
+
+    it('converts to an did', async ()=> {
+        const key = await EcdsaKey.generate()
+        const addr = await key.toDid()
+        const parts = addr.split(":")
+        expect(parts[0]).to.equal('did')
+        expect(parts[1]).to.equal('tupelo')
+        expect(parts[2]).to.have.length(42)
+    })
 })

--- a/src/crypto.spec.ts
+++ b/src/crypto.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import 'mocha'
 import {EcdsaKey} from './crypto'
+import { PublicKey } from 'tupelo-messages/signatures/signatures_pb'
 
 describe('EcdsaKeys', ()=> {
     it('generates a pair', async ()=> {
@@ -22,5 +23,12 @@ describe('EcdsaKeys', ()=> {
             expect(key.publicKey).to.have.length(65)
             expect(key.privateKey).to.have.length(32)
         }
+    })
+
+    it('generates a publicKeyProtobuf', async ()=> {
+        const key = await EcdsaKey.generate()
+        const pb = key.toPublicKeyPB()
+        expect(pb.getPublicKey_asU8()).to.equal(key.publicKey)
+        expect(pb.getType()).to.equal(PublicKey.Type.KEYTYPESECP256K1)
     })
 })

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,5 +1,5 @@
 import {Tupelo} from './tupelo'
-import { Signature } from 'tupelo-messages/signatures/signatures_pb'
+import { Signature, PublicKey } from 'tupelo-messages/signatures/signatures_pb'
 
 /**
  * EcdsaKey defines the public/private key-pairs used to interact with Tupelo.
@@ -60,5 +60,16 @@ export class EcdsaKey {
      */
     async keyAddr() {
         return this.toDid()
+    }
+
+    /**
+     * toPublicKeyPB is used to more easily create the public key for ownership
+     * @internal
+     */
+    toPublicKeyPB() {
+        const publicKey = new PublicKey()
+        publicKey.setPublicKey(this.publicKey)
+        publicKey.setType(PublicKey.Type.KEYTYPESECP256K1)
+        return publicKey
     }
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,5 +1,5 @@
 import {Tupelo} from './tupelo'
-import { Signature, PublicKey } from 'tupelo-messages/signatures/signatures_pb'
+import { Signature, PublicKey, Ownership } from 'tupelo-messages/signatures/signatures_pb'
 
 /**
  * EcdsaKey defines the public/private key-pairs used to interact with Tupelo.
@@ -43,7 +43,9 @@ export class EcdsaKey {
      * @public
      */
     async address() {
-        return Tupelo.ecdsaPubkeyToAddress(this.publicKey)
+        const ownership = new Ownership()
+        ownership.setPublicKey(this.toPublicKeyPB())
+        return Tupelo.ownershipToAddress(ownership)
     }
 
     /**
@@ -51,7 +53,7 @@ export class EcdsaKey {
      * @public
      */
     async toDid() {
-        return Tupelo.ecdsaPubkeyToDid(this.publicKey)
+        return "did:tupelo:" + (await this.address())
     }
     
     /**

--- a/src/tupelo.spec.ts
+++ b/src/tupelo.spec.ts
@@ -7,41 +7,21 @@ import { EcdsaKey } from './crypto';
 import ChainTree, { setDataTransaction, establishTokenTransaction, mintTokenTransaction, sendTokenTransaction } from './chaintree/chaintree';
 import { Proof } from 'tupelo-messages/gossip/gossip_pb';
 import { Community } from './community/community';
-import Repo from './repo';
 import debug from 'debug';
+import { Ownership } from 'tupelo-messages/signatures/signatures_pb';
 
 // import {LocalCommunity} from 'local-tupelo';
 
 const debugLog = debug("tupelospec")
 
-const MemoryDatastore: any = require('interface-datastore').MemoryDatastore;
-
-const testRepo = async () => {
-  const repo = new Repo('test', {
-    lock: 'memory',
-    storageBackends: {
-      root: MemoryDatastore,
-      blocks: MemoryDatastore,
-      keys: MemoryDatastore,
-      datastore: MemoryDatastore
-    }
-  })
-  await repo.init({})
-  await repo.open()
-  return repo
-}
-
 describe('Tupelo', () => {
-  it('gets a DID from a publicKey', async () => {
+  it('generates an address from an ownership', async ()=> {
     const key = await EcdsaKey.generate()
-    const did = await Tupelo.ecdsaPubkeyToDid(key.publicKey)
-    expect(did).to.include("did:tupelo:")
-    expect(did).to.have.lengthOf(53)
-  })
 
-  it('gets an address from a publicKey', async () => {
-    const key = await EcdsaKey.generate()
-    const addr = await Tupelo.ecdsaPubkeyToAddress(key.publicKey)
+    const ownership = new Ownership()
+    ownership.setPublicKey(key.toPublicKeyPB())
+    
+    const addr = await Tupelo.ownershipToAddress(ownership)
     expect(addr).to.have.lengthOf(42)
   })
 

--- a/src/tupelo.ts
+++ b/src/tupelo.ts
@@ -8,6 +8,8 @@ import ChainTree from './chaintree/chaintree';
 import { Proof } from 'tupelo-messages/gossip/gossip_pb';
 import { NotaryGroup } from 'tupelo-messages/config/config_pb';
 import debug from 'debug'
+import { Ownership } from 'tupelo-messages/signatures/signatures_pb';
+import { EcdsaKey } from './crypto';
 
 const logger = debug("tupelo")
 
@@ -59,11 +61,8 @@ class UnderlyingWasm {
     keyFromPrivateBytes(bytes: Uint8Array): Promise<Uint8Array[]> {
         return new Promise<Uint8Array[]>((res, rej) => { }) // replaced by wasm
     }
-    ecdsaPubkeyToDid(pubKey: Uint8Array): Promise<string> {
-        return new Promise<string>((res, rej) => { }) // replaced by wasm
-    }
-    ecdsaPubkeyToAddress(pubKey: Uint8Array): Promise<string> {
-        return new Promise<string>((res, rej) => { }) // replaced by wasm
+    ownershipToAddress(ownership:Uint8Array):Promise<string> {
+        return new Promise<string>((res,rej)=>{}) // replaced by wasm
     }
     getTip(did:string): Promise<Uint8Array> {
         return new Promise<Uint8Array>((res, rej) => { }) // replaced by wasm
@@ -140,16 +139,35 @@ export namespace Tupelo {
         return tw.keyFromPrivateBytes(bytes)
     }
 
-    export async function ecdsaPubkeyToDid(pubKey: Uint8Array): Promise<string> {
+    /**
+     * 
+     * @deprecated - use EcdsaKey#toDid() instead
+     */
+    export function ecdsaPubkeyToDid(pubKey: Uint8Array): Promise<string> {
         logger("ecdsaPubkeyToDid")
-        const tw = await TupeloWasm.get()
-        return tw.ecdsaPubkeyToDid(pubKey)
+        const key = new EcdsaKey(pubKey)
+        return key.toDid()
     }
 
-    export async function ecdsaPubkeyToAddress(pubKey: Uint8Array): Promise<string> {
+    /**
+     * 
+     * @deprecated - use EcdaKey#address() instead
+     */
+    export function ecdsaPubkeyToAddress(pubKey: Uint8Array): Promise<string> {
         logger("ecdsaPubkeyToAddress")
+        const key = new EcdsaKey(pubKey)
+        return key.address()
+    }
+
+    /**
+     * ownershipToAddress takes an Ownership and converts it to an address
+     * this address is suitable for setOwnership transactions
+     * @param ownership - the Ownership protobuf to convert into an address
+     */
+    export async function ownershipToAddress(ownership: Ownership): Promise<string> {
+        logger("ownershipToAddress")
         const tw = await TupeloWasm.get()
-        return tw.ecdsaPubkeyToAddress(pubKey)
+        return tw.ownershipToAddress(ownership.serializeBinary())
     }
 
     export async function getTip(did:string): Promise<Proof> {


### PR DESCRIPTION
This requires https://github.com/quorumcontrol/tupelo-go-sdk/pull/188 but is the JS interface to using conditions and preImage. It's not quite as elegant as the go side, but it works, is tested and has a standard place to add more options (which unfortunately right now have to be hard coded).

