### PR TITLE
add get latest

### DIFF
--- a/src/chaintree/chaintree.spec.ts
+++ b/src/chaintree/chaintree.spec.ts
@@ -39,6 +39,21 @@ describe('ChainTree', ()=> {
         expect(id).to.include("did:tupelo:")
     })
 
+    it('gets latest tree', async ()=> {
+      const key = await EcdsaKey.generate()
+      const c = await Community.getDefault()
+
+      const tree = await ChainTree.newEmptyTree(c.blockservice, key)
+      expect(tree).to.exist
+
+      const did = await tree.id()
+
+      await c.playTransactions(tree, [setDataTransaction("/path/to/somewhere", true)])
+      
+      const retTree = await ChainTree.getLatest(did!)
+      expect(retTree.tip.equals(tree.tip)).to.be.true
+    })
+
     it('resolves data', async ()=> {
       const key = await EcdsaKey.generate()
       const c = await Community.getDefault()

--- a/src/chaintree/chaintree.ts
+++ b/src/chaintree/chaintree.ts
@@ -43,6 +43,15 @@ export class ChainTree extends Dag {
     }
 
     /**
+     * getLatest returns a ChainTree with the newest state already cached in the local repo
+     * @param did - the did of the tree
+     * @public
+     */
+    static getLatest = async(did:string) => {
+        return Tupelo.getLatest(did)
+    }
+
+    /**
      * Creates a new ChainTree
      * @param opts - {@link IChainTreeInitializer}
      * @public


### PR DESCRIPTION
This upgrades the go-sdk (past master to https://github.com/quorumcontrol/tupelo-go-sdk/pull/202)

It also adds `ChainTree.getLatest(did)` which will use the go-sdk to do a getLatest and then return a ChainTree with the latest tip already in local storage.