### PR TITLE
quick fix to unblock testing, hard-codes the signer WSS addresses

### DIFF
--- a/src/community/community.ts
+++ b/src/community/community.ts
@@ -11,7 +11,7 @@ import { _getDefault, _setDefault } from './default';
 
 import debug from 'debug'
 import Repo from '../repo';
-import tomlToNotaryGroup, { notaryGroupToSignerPeerIds } from '../notarygroup';
+import tomlToNotaryGroup, { notaryGroupToSignerPeerIds, IPeerId } from '../notarygroup';
 
 const debugLog = debug("community")
 
@@ -152,6 +152,8 @@ export class Community extends EventEmitter {
 export async function afterQuorumSignersConnected(node:IP2PNode, group:NotaryGroup):Promise<void> {
     const peerIds = await notaryGroupToSignerPeerIds(group)
     const minConnected = Math.ceil((peerIds.length / 3) * 2)
+
+    debugLog(`waiting for ${minConnected} signers to connect, list: `, peerIds.map((id:IPeerId)=>{return id.toB58String()}))
 
     return new Promise((resolve) => {
         let connected = 0

--- a/src/community/default.ts
+++ b/src/community/default.ts
@@ -11,6 +11,13 @@ const testNetToml = `id = "gossip4"
 BootstrapAddresses = [
   "/dns4/94sgcr.bootstrap.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAmQgHD5eqxDskKe21ythvG2T9o5i521kEdLrdgjc94sgCr",
   "/dns4/ny3jzn.bootstrap.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAmNBupyDCfGSqo6ypNUmpHbYWy4jSaTBsbz6uRnsnY3JZN",
+
+  "/dns4/aWhvhW.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAmKXvLcaabkxaHBC56AXFRf96ELCEpMDicnaewF4aWhvhW",
+  "/dns4/odWBas.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAmAFZSNoqNLZZ53Pv9YcnvWSZfQpqfmRxRUrw5E9odWBas",
+  "/dns4/XbNSzA.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAmB8wCC2fFprjoSkfwAhfHtH1hFbpxE3XfrVFCiTXbNSzA",
+  "/dns4/1aEziG.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAm9vCSNtmNXEH2Gp5qFD1HUuz9cpHKWsqiX8WR7X1aEziG",
+  "/dns4/bNf5XD.ssl.quorumcontrol.com/tcp/443/wss/ipfs/16Uiu2HAm6TqxoQKE3geT4UACQwcz8fnf4F3RxcoSc2xYg7bNf5XD",
+  
   "/ip4/52.88.225.180/tcp/34001/ipfs/16Uiu2HAmQgHD5eqxDskKe21ythvG2T9o5i521kEdLrdgjc94sgCr",
   "/ip4/15.188.248.188/tcp/34001/ipfs/16Uiu2HAmNBupyDCfGSqo6ypNUmpHbYWy4jSaTBsbz6uRnsnY3JZN",
 ]
@@ -80,7 +87,6 @@ export const _getDefault = (repo?:Repo): Promise<Community> => {
 
         const c = new Community(node, defaultNotaryGroup, repo.repo)
     
-        log("waiting for signers connected")
         afterQuorumSignersConnected(node, defaultNotaryGroup).then(()=> {
             log("enough signers connected, starting community")
             resolve(c.start())


### PR DESCRIPTION
There seems to be an issue with discovering some of the signers in the notary group. This is a quick-fix to unblock release testing which adds in the signer WSS addresses to bootstrap.