### PR TITLE
switch back to using @latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,6 @@ jobs:
       - run: npm install
       - name: version check
         run: scripts/ci-release-ver-check.sh
-      - run: npm publish --tag next
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
The latest 0.6.0 tag wasn't pushed to latest so it won't be the default. This fixes it so master now publishes @latest . See: https://www.npmjs.com/package/tupelo-wasm-sdk (versions).