### PR TITLE
1.14 fixes for the browser

### DIFF
--- a/browsertest/package-lock.json
+++ b/browsertest/package-lock.json
@@ -10440,6 +10440,7 @@
         "ipfs-block-service": "^0.16.0",
         "ipfs-repo": "^0.30.1",
         "ipld": "^0.25.3",
+        "ipld-dag-cbor": "^0.15.2",
         "libp2p": "^0.26.2",
         "libp2p-bootstrap": "^0.9.7",
         "libp2p-crypto": "^0.17.1",
@@ -10909,6 +10910,50 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "borc": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+          "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "^9.0.0",
+            "buffer": "^5.5.0",
+            "commander": "^2.15.0",
+            "ieee754": "^1.1.13",
+            "iso-url": "~0.4.7",
+            "json-text-sequence": "~0.1.0",
+            "readable-stream": "^3.6.0"
+          },
+          "dependencies": {
+            "buffer": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+              "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            },
+            "iso-url": {
+              "version": "0.4.7",
+              "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+              "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
             }
           }
         },
@@ -12201,6 +12246,107 @@
           "requires": {
             "cids": "~0.7.0",
             "class-is": "^1.1.0"
+          }
+        },
+        "ipld-dag-cbor": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.2.tgz",
+          "integrity": "sha512-Ioni4s959P/CtkWQOt1TXrj4zqc3MoPxvHrEmybCn5JFdG3dpBNJR1oBVvP6uUrmF5bBtUGKNbX1pSI5SEOaHg==",
+          "dev": true,
+          "requires": {
+            "borc": "^2.1.2",
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "is-circular": "^1.0.2",
+            "multicodec": "^1.0.0",
+            "multihashing-async": "~0.8.0"
+          },
+          "dependencies": {
+            "base-x": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+              "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "buffer": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+              "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            },
+            "cids": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
+              "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "class-is": "^1.1.0",
+                "multibase": "~0.7.0",
+                "multicodec": "^1.0.1",
+                "multihashes": "~0.4.17"
+              },
+              "dependencies": {
+                "multicodec": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
+                  "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+                  "dev": true,
+                  "requires": {
+                    "buffer": "^5.5.0",
+                    "varint": "^5.0.0"
+                  }
+                }
+              }
+            },
+            "err-code": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
+              "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw==",
+              "dev": true
+            },
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "0.4.19",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
+              "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "multibase": "^0.7.0",
+                "varint": "^5.0.0"
+              }
+            },
+            "multihashing-async": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+              "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+              "dev": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "~0.8.0",
+                "multihashes": "~0.4.15",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
           }
         },
         "is-arguments": {

--- a/localtupelo/configs/localdocker.toml
+++ b/localtupelo/configs/localdocker.toml
@@ -4,6 +4,7 @@ BootstrapAddresses = [
     "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5",
     "/ip4/172.16.238.11/tcp/50001/ws/ipfs/16Uiu2HAmVGfmbkFFe3c9tHUioE2Q8j7VYrTDAn7Q6bH7coJPvUpv",
     "/ip4/127.0.0.1/tcp/50001/ws/ipfs/16Uiu2HAmVGfmbkFFe3c9tHUioE2Q8j7VYrTDAn7Q6bH7coJPvUpv",
+    "/ip4/172.16.238.10/tcp/50000/ws/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5", #bootstrap node websocket is last
     "/ip4/127.0.0.1/tcp/50000/ws/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5", #bootstrap node websocket is last
 ]
 [[signers]]

--- a/src/js/go/index.js
+++ b/src/js/go/index.js
@@ -4,6 +4,7 @@
 
 const log = require('debug')('gowasm');
 const isNodeJS = require('detect-node');
+const buffer = require('buffer');
 
 require("./wasm_exec"); // require here for the side effect of establishing global.Go
 
@@ -27,10 +28,17 @@ global.Go.readyPromise = new Promise((resolve) => {
     global.Go.readyResolver = resolve;
 });
 
+if (!global.Buffer) {
+    global.Buffer = buffer.Buffer;
+}
+
+if (!global.process.title) {
+    global.process.title = window.navigator.userAgent
+}
+
 const runner = {
     run: async () => {
         log('outer go.run')
-        const isNodeJS = global.process && global.process.title.indexOf("node") !== -1;
 
         const go = new Go();
         go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);

--- a/src/js/go/wasm_exec.js
+++ b/src/js/go/wasm_exec.js
@@ -39,9 +39,14 @@ const golog = require('debug')('go');
 		return err;
 	};
 
-	if (!global.fs) {
+	// Tupelo note: added the check for writeSync and the merging of these ontop of the existing here
+	// not sure why we need that here maybe some other package we use adds a global.fs (but not enough of it)
+	// so we instead do a little more checking and keep whatever the other thing wrote.
+	if (!global.fs || !global.fs.writeSync) {
+		const existingFs = global.fs || {}
 		let outputBuf = "";
 		global.fs = {
+			...existingFs, // merge these on top
 			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1 }, // unused
 			writeSync(fd, buf) {
 				outputBuf += decoder.decode(buf);

--- a/src/js/p2p/index.js
+++ b/src/js/p2p/index.js
@@ -11,13 +11,13 @@ const crypto = require('libp2p-crypto').keys
 const PeerId = require('peer-id')
 const TCP = require('libp2p-tcp')
 const util = require('util')
+const isNodeJS = require('detect-node')
 
 const log = require('debug')("p2p")
 
 const discovery = require('./discovery')
 const WssPeerBook = require('./wss-peer-book')
   
-const isNodeJS = global.process && global.process.title.indexOf("node") !== -1;
 
 class TupeloP2P extends libp2p {
   constructor (_options) {


### PR DESCRIPTION
I noticed this while testing the latest code in the browser. I missed a few places where we modified the go wasm_exec.js which are specific to the browser (nodejs tests were passing).

This fixes those last few things and the browsertest tests pass again.