### PR TITLE
allow multiple wasm files to peacefully co-exist

### DIFF
--- a/etc/tupelo-wasm-sdk.api.md
+++ b/etc/tupelo-wasm-sdk.api.md
@@ -325,6 +325,8 @@ export namespace Tupelo {
     // (undocumented)
     export function newEmptyTree(store: IBlockService, publicKey: Uint8Array): Promise<CID_2>;
     // (undocumented)
+    export function newNamedTree(namespace: string, name: string, owners: string[]): Promise<CID_2>;
+    // (undocumented)
     export function passPhraseKey(phrase: Uint8Array, salt: Uint8Array): Promise<Uint8Array[]>;
     // (undocumented)
     export function playTransactions(tree: ChainTree, transactions: Transaction[]): Promise<Proof>;

--- a/src/tupelo.ts
+++ b/src/tupelo.ts
@@ -1,6 +1,6 @@
 import CID from 'cids';
 
-const go = require('./js/go')
+const Go = require('./js/go')
 import { Transaction } from 'tupelo-messages'
 import { TokenPayload } from 'tupelo-messages/transactions/transactions_pb'
 import { IBlockService, IBlock } from './chaintree/dag/dag'
@@ -105,9 +105,9 @@ namespace TupeloWasm {
         _tupelowasm = new Promise(async (resolve, reject) => {
             const wasm = new UnderlyingWasm;
             logger("go.run for first time");
-            go.run("./main.wasm");
+            const go = await Go.run();
             await go.ready();
-            go.populate(wasm, {
+            go.populateLibrary(wasm, {
                 "cids": CID,
                 "ipfs-block": require('ipfs-block'),
             });


### PR DESCRIPTION
This uses https://github.com/quorumcontrol/tupelo/pull/479 and gets rid of (most of) the global Go stuff and instead exposes a "go" (little g) object to the wasm files themselves. 